### PR TITLE
Refactor streams to kafka client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.idea
 kafka-elasticsearch-data--pump.iml
 target
+kafka-elasticsearch-data-pump.iml

--- a/README.md
+++ b/README.md
@@ -47,5 +47,22 @@ the service exposes two resources:
     
 #### Running the image
 
-    docker run -d -p 8080:8080 --name kafka-elasticsearch-data-pump toefel/kafka-elasticsearch-data-pump:v1
+    docker run -d -p 8080:8080 --name kafka-elasticsearch-data-pump toefel/kafka-elasticsearch-data-pump:latest
+   
+#### development set-up
+    
+    # start a single elasticsearch container  
+    docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.1.2
+   
+    # kibana will try to find elasticsearch on  elasticsearch.url http://elasticsearch:9200, so the --link accomplishes that
+    docker run -d --name kibana --link elasticsearch:elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:6.1.2
+    
+    # start a development kafka
+    docker run -d --name kafka -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=<YOUR MACHINE IP ADDRESS> --env ADVERTISED_PORT=9092 spotify/kafka
+    
+    # start the pump
+    docker run -d --name kafka-elasticsearch-data-pump -p 8080:8080 toefel/kafka-elasticsearch-data-pump:latest
+    
+    # use example-config.json as a base, and fill in the correct numbers!
+    # elasticsearchServer and kafkaBootstrapServers must be reachable from within the pump container 
     

--- a/README.md
+++ b/README.md
@@ -3,20 +3,75 @@
 Service that takes incoming streams from kafka topics and writes them
 to elasticsearch in a configurable way.
 
-Quickstart:
+## Quickstart using Docker (local one node cluster)
+    
+TODO provide a docker-compose file that spins this all up.    
+    
+ 1. Get your IP address 
+  
+        hostname -I  
+        
+ 1. Start a single elasticsearch container  
+    
+        docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.1.2
+   
+ 1. Kibana will try to find elasticsearch on  elasticsearch.url http://elasticsearch:9200, so the --link accomplishes that
+    
+        docker run -d --name kibana --link elasticsearch:elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:6.1.2
+    
+ 1. Start a development kafka
+ 
+        docker run -d --name kafka -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=<YOUR MACHINE IP ADDRESS> --env ADVERTISED_PORT=9092 spotify/kafka
+    
+ 1. Start the data pump
+        
+        docker run -d --name kafka-elasticsearch-data-pump -p 8080:8080 toefel/kafka-elasticsearch-data-pump:latest
+ 
+ 1. Configure the data pump
+ 
+    Create a configuration file similar to this and save it as `~/data-pump-config.json`:
+ 
+        {
+          "kafkaConsumerGroupId" : "kafka-elasticsearch-data-pump-1",
+          "kafkaBootstrapServers" : "<YOUR MACHINE IP ADDRESS>:9092",
+          "elasticsearchServer" : "<YOUR MACHINE IP ADDRESS>:9200",
+          "topicMappings" : [ {
+            "topic" : "any-topic-you-like",
+            "elasticsearchIndex" : "kafka-topics-data-pump-tester",
+            "elasticsearchType" : "data-pump-tester",
+            "elasticsearchIdStrategy" : "auto",
+            "addKafkaMetaData" : true,
+            "configureTimestampInType" : true,
+            "logCurlCommands" : "always"
+          }, {
+            "topic" : "flow-unit-status",
+            "elasticsearchIndex" : "kafka-topics-flow-unit-status",
+            "elasticsearchType" : "flow-unit-status",
+            "elasticsearchIdStrategy" : "auto",
+            "addKafkaMetaData" : true,
+            "configureTimestampInType" : true,
+            "logCurlCommands" : "always"
+          }]
+        }
+    
+    Configure the service to use that config:
+    
+        curl -XPUT -d @~/data-pump-config.json http://localhost:8080/configuration
+        
+    This configuration is persisted within the container, a restart of the container will immediately start with this 
+    config. 
+ 
+Your messages should now end up in Elasticsearch, to view them with Kibana:
 
-    docker pull toefel/kafka-elasticsearch-data-pump
-    docker run -d --name kafka-elasticsearch-data-pump -p 8080:8080 toefel/kafka-elasticsearch-data-pump
-    
-    #Then view the logs to see if it's running.
-    
-    docker logs kafka-elasticsearch-data-pump
-    
-    #Then configure it via REST
-    curl -XPUT -d @example-config.json localhost:8080/configuration
-    
-Your messages should now end up in ELK. if Elasticsearch requires authentication, that is not yet supported
-
+ 1. Open [kibana](kibana at http://localhost:8080)
+ 1. Goto Management > Index patterns > Create Index Pattern
+ 1. Enter `kafka-topics-*` as the pattern and click *Next Step*
+ 1. Choose `timestamp` as the Time filter field name and click *Create index pattern*
+ 1. Goto Discover and click on the time clock at the top right (probably saying `Last 15 minutes`)
+ 1. Select `Last year`
+ 1. You should now see all your kafka messages 
+  
+**Authentication on elasticsearch is not yet supported**
 
 #Development
 
@@ -33,36 +88,53 @@ To start this service:
 the service exposes two resources:
 
  * /configuration 
-    - GET retrieves the currently active [Config](src/main/java/nl/toefel/kafka/elasticsearch/pump/config/Config.java)
+    - GET retrieves the currently active and possible error information. [Config](src/main/java/nl/toefel/kafka/elasticsearch/pump/config/Config.java)
     - PUT activates a new [Config](src/main/java/nl/toefel/kafka/elasticsearch/pump/config/Config.java) and restarts the streaming application. This config is persisted in `<HOME>/.kafka-elasticsearch-data-pump/config.json` and automatically reloaded on startup. 
- * /topology
-    - GET retrieves the currently active Kafka Streams Topology. 
+ * /statistics
+    - GET retrieves the collected internal statistics
+    - DELETE retrieves the collected internal statistics and resets them afterwards
+    
+### Configuration options    
+      
+        {
+          "kafkaConsumerGroupId" : "kafka-elasticsearch-data-pump-1",  // the kafka-consumer-group to use
+          "kafkaBootstrapServers" : "<YOUR MACHINE IP ADDRESS>:9092",  // kafka address, comma separated list host:port 
+          "elasticsearchServer" : "<YOUR MACHINE IP ADDRESS>:9200",    // an elasticsearch server address, single item!
+          "topicMappings" : [ {                                        // list of per-topic configurations
+            "topic" : "any-topic-you-like",                            // the name of the topic to consume from
+            "elasticsearchIndex" : "kafka-topics-data-pump-tester",    // the elasticsearch index to put messages in (created automatically if not exists)
+            "elasticsearchType" : "data-pump-tester",                  // the elasticsearch type to use/create (created automatically if not exists)
+            "elasticsearchIdStrategy" : "auto",                        // Options are "auto": let elasticsearch determine the ID of each message  
+                                                                       //             "fromKafkaKey": use the key in the kafka message as ID (know what you are doing!)
+                                                                       //             "fromField": (not yet implemented, but would require a jsonpath to the field in the message)
+                                                                       //             "random": generate a random UUID.
+                                                                       //             the default is auto 
+            "addKafkaMetaData" : true,                                 // Add all the information from a ConsumerRecord like topic, partition, offset, message size, etc
+                                                                       // to the message posted to elasticsearch with the field _kafkaMetaData (so that you can use this in aggregations)  
+            "configureTimestampInType" : true,                         // Configure elasticsearch type to use timestamp as the time identifier
+                                                                       // The data pump harmonizes all timestamp fields to make sure you can use the time filter in kibana.
+            "logCurlCommands" : "always"                               // always: logs each call to elasticsearch as a curl command, allow manual retries
+                                                                       // onFailure: log failed calls to elasticsearch as a curl command, to allow manual fixing
+          }, {
+            "topic" : "flow-unit-status",
+            "elasticsearchIndex" : "kafka-topics-flow-unit-status",
+            "elasticsearchType" : "flow-unit-status",
+            "elasticsearchIdStrategy" : "auto",
+            "addKafkaMetaData" : true,
+            "configureTimestampInType" : true,
+            "logCurlCommands" : "always"
+          }]
+        }
     
 ## Docker
 
 #### Building an image
 
-    docker build -t toefel/kafka-elasticsearch-data-pump:v1 .
+    mvn clean install
+    docker build -t toefel/kafka-elasticsearch-data-pump:latest .
     docker push
     
 #### Running the image
 
     docker run -d -p 8080:8080 --name kafka-elasticsearch-data-pump toefel/kafka-elasticsearch-data-pump:latest
    
-#### development set-up
-    
-    # start a single elasticsearch container  
-    docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.1.2
-   
-    # kibana will try to find elasticsearch on  elasticsearch.url http://elasticsearch:9200, so the --link accomplishes that
-    docker run -d --name kibana --link elasticsearch:elasticsearch -p 5601:5601 docker.elastic.co/kibana/kibana:6.1.2
-    
-    # start a development kafka
-    docker run -d --name kafka -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=<YOUR MACHINE IP ADDRESS> --env ADVERTISED_PORT=9092 spotify/kafka
-    
-    # start the pump
-    docker run -d --name kafka-elasticsearch-data-pump -p 8080:8080 toefel/kafka-elasticsearch-data-pump:latest
-    
-    # use example-config.json as a base, and fill in the correct numbers!
-    # elasticsearchServer and kafkaBootstrapServers must be reachable from within the pump container 
-    

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@
 Service that takes incoming streams from kafka topics and writes them
 to elasticsearch in a configurable way.
 
+Quickstart:
+
+    docker pull toefel/kafka-elasticsearch-data-pump
+    docker run -d --name kafka-elasticsearch-data-pump -p 8080:8080 toefel/kafka-elasticsearch-data-pump
+    
+    #Then view the logs to see if it's running.
+    
+    docker logs kafka-elasticsearch-data-pump
+    
+    #Then configure it via REST
+    curl -XPUT -d @example-config.json localhost:8080/configuration
+    
+Your messages should now end up in ELK. if Elasticsearch requires authentication, that is not yet supported
+
+
+#Development
+
 Requires maven 3.5 and Java 9.
 
 To start this service: 

--- a/example-config.json
+++ b/example-config.json
@@ -8,42 +8,54 @@
       "elasticsearchIndex": "kafka-topics-flow-unit-status",
       "elasticsearchType": "flow-unit-status",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     },
     {
       "topic": "flow-trip-mutations",
       "elasticsearchIndex": "kafka-topics-flow-trip-mutations",
       "elasticsearchType": "flow-trip-mutations",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     },
     {
       "topic": "flow-to-be-planned-shipments",
       "elasticsearchIndex": "kafka-topics-flow-to-be-planned-shipments",
       "elasticsearchType": "flow-to-be-planned-shipments",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     },
     {
       "topic": "flow-loaded-trips",
       "elasticsearchIndex": "kafka-topics-flow-loaded-trips",
       "elasticsearchType": "flow-loaded-trips",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     },
     {
       "topic": "flow-released-trips",
       "elasticsearchIndex": "kafka-topics-flow-released-trips",
       "elasticsearchType": "flow-released-trips",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     },
     {
       "topic": "flow-ht-events",
       "elasticsearchIndex": "kafka-topics-flow-ht-events",
       "elasticsearchType": "flow-ht-events",
       "elasticsearchIdStrategy": "auto",
-      "configureTimestampInType": true
+      "addKafkaMetaData": true,
+      "configureTimestampInType": true,
+      "logCurlCommands": "always"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>patan</artifactId>
             <version>4.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>1.0.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,4 +15,6 @@ module nl.toefel.kafka.elasticsearch.pump {
     exports nl.toefel.kafka.elasticsearch.pump;
     exports nl.toefel.kafka.elasticsearch.pump.config;
     exports nl.toefel.kafka.elasticsearch.pump.http;
+    exports nl.toefel.kafka.elasticsearch.pump.kafka;
+    exports nl.toefel.kafka.elasticsearch.pump.sink;
 }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableKafkaKafkaSource.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableKafkaKafkaSource.java
@@ -30,189 +30,189 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  * @author Christophe Hesters
  */
-@Deprecated() // Does not support older kafka versions and does not play wel with .NET and Golang clients missing timestamps
-public class ConfigurableKafkaKafkaSource implements kafka.ConfigurableKafkaSource {
-
-    private static final String TYPE_CONFIG = "{\"mappings\":{\"${TYPE}\":{\"properties\":{\"timestamp\":{\"type\":\"date\"}}}}}";
-
-    public static final Statistics STATS = StatisticsFactory.createThreadsafeStatistics();
-    private final HttpClient http = HttpClient.newHttpClient();
-    private KafkaStreams activeStreams;
-    private Lock lock = new ReentrantLock();
-    private Topology topology = null;
-    private Config config = Config.newEmpty();
-
-    /**
-     * Reconfigures the streams without waiting if a reconfiguration is already in progress.
-     * @param config
-     * @return true if successful, false if a reconfiguration was already in progress.
-     */
-    @Override
-    public boolean reconfigureOrCancel(Config config) {
-        if (lock.tryLock()) {
-            try {
-                reconfigureStreamsImpl(config);
-                return true;
-            } finally {
-                lock.unlock();
-            }
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Reconfigures the streams or waits until streams is ready if a configuration is already in progress.
-     * @param config
-     */
-    @Override
-    public void reconfigureOrWait(Config config) {
-        lock.lock();
-        try {
-            reconfigureStreamsImpl(config);
-        }finally {
-            lock.unlock();
-        }
-    }
-
-    private void reconfigureStreamsImpl(Config config) {
-        System.out.println("Using config: \n" + Jsonizer.toJsonFormatted(config));
-        if (config.isEmpty()) {
-            System.out.println("Config is empty, not starting any streams");
-            return;
-        }
-        if (!config.isValid()) {
-            System.out.println("Not altering config due to invalid parameters");
-            return;
-        }
-        if (activeStreams != null) {
-            System.out.println("Closing active streams");
-            activeStreams.close();
-        }
-        this.config = config;
-        Properties props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, config.kafkaConsumerGroupId);
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, config.kafkaBootstrapServers);
-        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
-
-        StreamsBuilder builder = new StreamsBuilder();
-        config.topicMappings.forEach(mapping -> {
-            preprocess(mapping, config);
-            builder.stream(mapping.topic)
-                    .filter(this::validJsonValues)
-                    .map(this::insertTimestamp)
-                    .foreach((key, val) -> onRecord(String.valueOf(key), val, mapping, config));
-        });
-
-        topology = builder.build();
-        System.out.println(topology.describe());
-
-        activeStreams = new KafkaStreams(topology, props);
-        persistConfig(config);
-        System.out.println("Starting KafkaStreams");
-        activeStreams.start();
-        System.out.println("KafkaStreams Started");
-    }
-
-    private void persistConfig(Config config) {
-        try {
-            System.out.println("Persisting configuration");
-            Files.deleteIfExists(Config.CONFIG_PATH);
-            Files.createFile(Config.CONFIG_PATH);
-            Files.write(Config.CONFIG_PATH, Jsonizer.toJsonFormattedBytes(config));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private void preprocess(TopicElasticsearchMapping mapping, Config config) {
-        Stopwatch sw = STATS.startStopwatch();
-        if (mapping.configureTimestampInType == null || mapping.configureTimestampInType) {
-            String uri = "http://" + Paths.get(config.elasticsearchServer, mapping.elasticsearchIndex, mapping.elasticsearchType);
-            String body = TYPE_CONFIG.replace("${TYPE}", mapping.elasticsearchType);
-            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
-                    .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyProcessor.fromString(body))
-                    .build();
-            try {
-                System.out.println("curl -XPUT -H 'Content-Type: application/json' " + uri + " -d '" + body + "'");
-                HttpResponse<String> response = http.send(request, HttpResponse.BodyHandler.asString());
-                System.out.println("Status: " + response.statusCode() + ", body: " + response.body());
-                STATS.recordElapsedTime("configurable.streams.preprocess.ok", sw);
-            } catch (IOException | InterruptedException e) {
-                System.out.println("Failed to send type configuration request to " + uri + ", with body: " + body);
-                STATS.recordElapsedTime("configurable.streams.preprocess.failed", sw);
-            }
-        }
-    }
-
-    private KeyValue<Object, String> insertTimestamp(Object key, Object val) {
-        Map<String, Object> parsedJson = Jsonizer.fromJson(String.valueOf(val));
-        Object timestamp = parsedJson.get("timestamp");
-        if (timestamp != null) {
-            parsedJson.put("originalTimestampInMessage", timestamp);
-        }
-        if (timestamp instanceof Long) {
-            parsedJson.put("timestamp", ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long)timestamp), ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
-        } else if (timestamp instanceof String) {
-            // nothing to do
-        } else {
-            System.out.println("INCOMPATIBLE TIMESTAMP FORMAT " + timestamp);
-            parsedJson.put("timestamp", ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
-        }
-        return KeyValue.pair(key, Jsonizer.toJsonMinified(parsedJson));
-    }
-
-    private void onRecord(String key, String value, TopicElasticsearchMapping mapping, Config config) {
-        Stopwatch sw = STATS.startStopwatch();
-        String uri = "http://" + Paths.get(
-                config.elasticsearchServer,
-                mapping.elasticsearchIndex,
-                mapping.elasticsearchType,
-                generateKey(mapping, key)).toString();
-        System.out.println("curl -XPUT -H 'Content-Type: application/json' " + uri + " -d '" + value + "'");
-        try {
-            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
-                    .header("Content-Type", "application/json")
-                    .PUT(HttpRequest.BodyProcessor.fromString(value)).build();
-            HttpResponse<String> response = http.send(request, HttpResponse.BodyHandler.asString());
-            if (response.statusCode() >= 300 || response.statusCode() < 200) {
-                System.out.println("error putting in elasticsearch " + response.statusCode() + " " + response.body());
-            }
-            STATS.recordElapsedTime("on.record." + mapping.topic + ".ok", sw);
-        } catch (IOException | InterruptedException e) {
-            STATS.recordElapsedTime("on.record." + mapping.topic + ".failed", sw);
-            e.printStackTrace();
-        }
-    }
-
-    private String generateKey(TopicElasticsearchMapping mapping, String key) {
-        if (mapping.elasticsearchIdStrategy == null || "auto".equalsIgnoreCase(mapping.elasticsearchIdStrategy)){
-            // https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation
-            return ""; // this will PUT on /, causing Elasticsearch to automatically determine ID.
-        } else if ("random".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
-            return UUID.randomUUID().toString();
-        } else if ("fromField".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
-            throw new IllegalStateException("not implemented, but would get key from " + String.valueOf(mapping.idFromField));
-        } else if ("fromKey".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
-            return key;
-        } else {
-            System.out.println("unknown strategy " + String.valueOf(mapping.elasticsearchIdStrategy) + ", defaulting to auto");
-            return "";
-        }
-    }
-
-    public Optional<TopologyDescription> getTopologyDescription() {
-        if (topology != null) {
-            return Optional.of(topology.describe());
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    @Override
-    public Config getConfig() {
-        return config;
-    }
-}
+//@Deprecated() // Does not support older kafka versions and does not play wel with .NET and Golang clients missing timestamps
+//public class ConfigurableKafkaKafkaSource implements kafka.ConfigurableKafkaSource {
+//
+//    private static final String TYPE_CONFIG = "{\"mappings\":{\"${TYPE}\":{\"properties\":{\"timestamp\":{\"type\":\"date\"}}}}}";
+//
+//    public static final Statistics STATS = StatisticsFactory.createThreadsafeStatistics();
+//    private final HttpClient http = HttpClient.newHttpClient();
+//    private KafkaStreams activeStreams;
+//    private Lock lock = new ReentrantLock();
+//    private Topology topology = null;
+//    private Config config = Config.newEmpty();
+//
+//    /**
+//     * Reconfigures the streams without waiting if a reconfiguration is already in progress.
+//     * @param config
+//     * @return true if successful, false if a reconfiguration was already in progress.
+//     */
+//    @Override
+//    public boolean reconfigureOrCancel(Config config) {
+//        if (lock.tryLock()) {
+//            try {
+//                reconfigureStreamsImpl(config);
+//                return true;
+//            } finally {
+//                lock.unlock();
+//            }
+//        } else {
+//            return false;
+//        }
+//    }
+//
+//    /**
+//     * Reconfigures the streams or waits until streams is ready if a configuration is already in progress.
+//     * @param config
+//     */
+//    @Override
+//    public void reconfigureOrWait(Config config) {
+//        lock.lock();
+//        try {
+//            reconfigureStreamsImpl(config);
+//        }finally {
+//            lock.unlock();
+//        }
+//    }
+//
+//    private void reconfigureStreamsImpl(Config config) {
+//        System.out.println("Using config: \n" + Jsonizer.toJsonFormatted(config));
+//        if (config.isEmpty()) {
+//            System.out.println("Config is empty, not starting any streams");
+//            return;
+//        }
+//        if (!config.isValid()) {
+//            System.out.println("Not altering config due to invalid parameters");
+//            return;
+//        }
+//        if (activeStreams != null) {
+//            System.out.println("Closing active streams");
+//            activeStreams.close();
+//        }
+//        this.config = config;
+//        Properties props = new Properties();
+//        props.put(StreamsConfig.APPLICATION_ID_CONFIG, config.kafkaConsumerGroupId);
+//        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, config.kafkaBootstrapServers);
+//        props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+//        props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass());
+//
+//        StreamsBuilder builder = new StreamsBuilder();
+//        config.topicMappings.forEach(mapping -> {
+//            preprocess(mapping, config);
+//            builder.stream(mapping.topic)
+//                    .filter(this::validJsonValues)
+//                    .map(this::insertTimestamp)
+//                    .foreach((key, val) -> onRecord(String.valueOf(key), val, mapping, config));
+//        });
+//
+//        topology = builder.build();
+//        System.out.println(topology.describe());
+//
+//        activeStreams = new KafkaStreams(topology, props);
+//        persistConfig(config);
+//        System.out.println("Starting KafkaStreams");
+//        activeStreams.start();
+//        System.out.println("KafkaStreams Started");
+//    }
+//
+//    private void persistConfig(Config config) {
+//        try {
+//            System.out.println("Persisting configuration");
+//            Files.deleteIfExists(Config.CONFIG_PATH);
+//            Files.createFile(Config.CONFIG_PATH);
+//            Files.write(Config.CONFIG_PATH, Jsonizer.toJsonFormattedBytes(config));
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    private void preprocess(TopicElasticsearchMapping mapping, Config config) {
+//        Stopwatch sw = STATS.startStopwatch();
+//        if (mapping.configureTimestampInType == null || mapping.configureTimestampInType) {
+//            String uri = "http://" + Paths.get(config.elasticsearchServer, mapping.elasticsearchIndex, mapping.elasticsearchType);
+//            String body = TYPE_CONFIG.replace("${TYPE}", mapping.elasticsearchType);
+//            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
+//                    .header("Content-Type", "application/json")
+//                    .POST(HttpRequest.BodyProcessor.fromString(body))
+//                    .build();
+//            try {
+//                System.out.println("curl -XPUT -H 'Content-Type: application/json' " + uri + " -d '" + body + "'");
+//                HttpResponse<String> response = http.send(request, HttpResponse.BodyHandler.asString());
+//                System.out.println("Status: " + response.statusCode() + ", body: " + response.body());
+//                STATS.recordElapsedTime("configurable.streams.preprocess.ok", sw);
+//            } catch (IOException | InterruptedException e) {
+//                System.out.println("Failed to send type configuration request to " + uri + ", with body: " + body);
+//                STATS.recordElapsedTime("configurable.streams.preprocess.failed", sw);
+//            }
+//        }
+//    }
+//
+//    private KeyValue<Object, String> insertTimestamp(Object key, Object val) {
+//        Map<String, Object> parsedJson = Jsonizer.fromJson(String.valueOf(val));
+//        Object timestamp = parsedJson.get("timestamp");
+//        if (timestamp != null) {
+//            parsedJson.put("originalTimestampInMessage", timestamp);
+//        }
+//        if (timestamp instanceof Long) {
+//            parsedJson.put("timestamp", ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long)timestamp), ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+//        } else if (timestamp instanceof String) {
+//            // nothing to do
+//        } else {
+//            System.out.println("INCOMPATIBLE TIMESTAMP FORMAT " + timestamp);
+//            parsedJson.put("timestamp", ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+//        }
+//        return KeyValue.pair(key, Jsonizer.toJsonMinified(parsedJson));
+//    }
+//
+//    private void onRecord(String key, String value, TopicElasticsearchMapping mapping, Config config) {
+//        Stopwatch sw = STATS.startStopwatch();
+//        String uri = "http://" + Paths.get(
+//                config.elasticsearchServer,
+//                mapping.elasticsearchIndex,
+//                mapping.elasticsearchType,
+//                generateKey(mapping, key)).toString();
+//        System.out.println("curl -XPUT -H 'Content-Type: application/json' " + uri + " -d '" + value + "'");
+//        try {
+//            HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
+//                    .header("Content-Type", "application/json")
+//                    .PUT(HttpRequest.BodyProcessor.fromString(value)).build();
+//            HttpResponse<String> response = http.send(request, HttpResponse.BodyHandler.asString());
+//            if (response.statusCode() >= 300 || response.statusCode() < 200) {
+//                System.out.println("error putting in elasticsearch " + response.statusCode() + " " + response.body());
+//            }
+//            STATS.recordElapsedTime("on.record." + mapping.topic + ".ok", sw);
+//        } catch (IOException | InterruptedException e) {
+//            STATS.recordElapsedTime("on.record." + mapping.topic + ".failed", sw);
+//            e.printStackTrace();
+//        }
+//    }
+//
+//    private String generateKey(TopicElasticsearchMapping mapping, String key) {
+//        if (mapping.elasticsearchIdStrategy == null || "auto".equalsIgnoreCase(mapping.elasticsearchIdStrategy)){
+//            // https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#_automatic_id_generation
+//            return ""; // this will PUT on /, causing Elasticsearch to automatically determine ID.
+//        } else if ("random".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
+//            return UUID.randomUUID().toString();
+//        } else if ("fromField".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
+//            throw new IllegalStateException("not implemented, but would get key from " + String.valueOf(mapping.idFromField));
+//        } else if ("fromKey".equalsIgnoreCase(mapping.elasticsearchIdStrategy.trim())) {
+//            return key;
+//        } else {
+//            System.out.println("unknown strategy " + String.valueOf(mapping.elasticsearchIdStrategy) + ", defaulting to auto");
+//            return "";
+//        }
+//    }
+//
+//    public Optional<TopologyDescription> getTopologyDescription() {
+//        if (topology != null) {
+//            return Optional.of(topology.describe());
+//        } else {
+//            return Optional.empty();
+//        }
+//    }
+//
+//    @Override
+//    public Config getConfig() {
+//        return config;
+//    }
+//}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableKafkaSource.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableKafkaSource.java
@@ -1,0 +1,11 @@
+package nl.toefel.kafka.elasticsearch.pump;
+
+import nl.toefel.kafka.elasticsearch.pump.config.Config;
+
+public interface ConfigurableKafkaSource {
+    boolean reconfigureOrCancel(Config config);
+
+    void reconfigureOrWait(Config config);
+
+    Config getConfig();
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableStringConsumer.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/ConfigurableStringConsumer.java
@@ -1,0 +1,79 @@
+package nl.toefel.kafka.elasticsearch.pump;
+
+import nl.toefel.kafka.elasticsearch.pump.config.Config;
+import nl.toefel.kafka.elasticsearch.pump.json.Jsonizer;
+import nl.toefel.kafka.elasticsearch.pump.kafka.KafkaStringConsumer;
+import nl.toefel.kafka.elasticsearch.pump.sink.ElasticsearchBulkHttpSink;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class ConfigurableStringConsumer implements ConfigurableKafkaSource {
+
+    private Lock lock = new ReentrantLock();
+    private Optional<KafkaStringConsumer> oneTryConsumer = Optional.empty();
+    private Config cfg;
+
+    /**
+     * Reconfigures the streams without waiting if a reconfiguration is already in progress.
+     *
+     * @param config
+     * @return true if successful, false if a reconfiguration was already in progress.
+     */
+    @Override
+    public boolean reconfigureOrCancel(Config config) {
+        if (lock.tryLock()) {
+            try {
+                reconfigure(config);
+                return true;
+            } finally {
+                lock.unlock();
+            }
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Reconfigures the streams or waits until streams is ready if a configuration is already in progress.
+     *
+     * @param config
+     */
+    @Override
+    public void reconfigureOrWait(Config config) {
+        lock.lock();
+        try {
+            reconfigure(config);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void reconfigure(Config config) {
+        System.out.println("Using config: \n" + Jsonizer.toJsonFormatted(config));
+        if (config.isEmpty()) {
+            System.out.println("Config is empty, not starting any streams");
+            return;
+        }
+        if (!config.isValid()) {
+            System.out.println("Not altering config due to invalid parameters");
+            return;
+        }
+        oneTryConsumer.ifPresent(consumer -> consumer.stopSync(5, TimeUnit.SECONDS));
+        cfg = config;
+        KafkaStringConsumer.newStartedConsumer(cfg, new ElasticsearchBulkHttpSink(cfg));
+    }
+
+
+    @Override
+    public Config getConfig() {
+        lock.lock();
+        try {
+            return cfg;
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/Main.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/Main.java
@@ -19,7 +19,9 @@ public class Main {
             cfg = Jsonizer.fromJson(Files.readAllBytes(Config.CONFIG_PATH), Config.class);
         }
 
-        ConfigurableKafkaSource kafkaSource = new ConfigurableStringConsumer();
+        ConfigurableStringConsumer kafkaSource = new ConfigurableStringConsumer();
+        kafkaSource.registerShutdownHook();
+
 
         // port cannot be part of Config, because the REST server receives the config.
         // the dockerfile also maps this port, changing it would render the service unreachable outside the docker network.

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/config/TopicElasticsearchMapping.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/config/TopicElasticsearchMapping.java
@@ -10,7 +10,8 @@ public class TopicElasticsearchMapping {
     public String elasticsearchIndex;
     public String elasticsearchType;
     public String elasticsearchIdStrategy;
-    public Optional<IdFromFieldInMessageKeyStrategy> idFromField;
+    public Boolean addKafkaMetaData;
+    public Optional<String> pathToIdInMessage;
     public Boolean configureTimestampInType;
-
+    public String logCurlCommands;
 }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/json/Jsonizer.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/json/Jsonizer.java
@@ -86,4 +86,5 @@ public class Jsonizer {
             throw new IllegalArgumentException(e);
         }
     }
+
 }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/kafka/KafkaStringConsumer.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/kafka/KafkaStringConsumer.java
@@ -13,6 +13,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static nl.toefel.kafka.elasticsearch.pump.statistics.Statistics.STATS;
+
 /**
  * Implementation based on article:
  * https://www.confluent.io/blog/tutorial-getting-started-with-the-new-apache-kafka-0-9-consumer-client/
@@ -29,6 +31,7 @@ public class KafkaStringConsumer {
         System.out.println("Starting a new kafka consumer with a subscription to topics " + topics);
         consumer.consumer.subscribe(topics);
         new Thread(consumer::pollForMessages).start();
+        STATS.engine.addOccurrence("kafka.string.consumer.created");
         return consumer;
     }
 
@@ -47,24 +50,29 @@ public class KafkaStringConsumer {
     }
 
     public void stopSync(long timeout, TimeUnit timeUnit) {
-        System.out.println("Closing kafka consumer with a maximum wait of " + timeout + " " + timeUnit.name());
-        consumer.wakeup();
-        try {
-            boolean consumerClosedProperly = latch.await(timeout, timeUnit);
-            System.out.println(consumerClosedProperly? "Kafka consumer stopped correctly" : "Kafka consumer did not respond to stop, something appears to be wrong");
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        STATS.engine.recordElapsedTime("kafka.string.consumer.stop.sync", () -> {
+            System.out.println("Closing kafka consumer with a maximum wait of " + timeout + " " + timeUnit.name());
+            consumer.wakeup();
+            try {
+                boolean consumerClosedProperly = latch.await(timeout, timeUnit);
+                System.out.println(consumerClosedProperly? "Kafka consumer stopped correctly" : "Kafka consumer did not respond to stop, something appears to be wrong");
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
     }
 
     private void pollForMessages() {
         System.out.println("Entering poll loop until consumer explicitly stopped");
         try {
+            // polls forever until a message is available, or throws WakeupException when .wakeup() is called via stopSync
             while (true) {
-                // polls forever until a message is available, or throws WakeupException when .wakeup() is called
-                ConsumerRecords<String, String> records = consumer.poll(Long.MAX_VALUE);
-                processExceptionSafe(records);
-                consumer.commitSync();
+                STATS.engine.recordElapsedTime("kafka.string.consumer.poll.for.messages", () -> {
+                    ConsumerRecords<String, String> records =
+                            STATS.engine.recordElapsedTime("kafka.string.consumer.poll.for.messages.poll", () -> consumer.poll(Long.MAX_VALUE));
+                    STATS.engine.recordElapsedTime("kafka.string.consumer.poll.for.messages.processExceptionSafe", () -> processExceptionSafe(records));
+                    STATS.engine.recordElapsedTime("kafka.string.consumer.poll.for.messages.commit.sync", () -> consumer.commitSync()); // TODO if this throws, we should not exit poll loop but wait for reconnect
+                });
             }
         } catch (WakeupException e) {
             // only happends when somebody calls .wakeup() on the consumer, indicating a shutdown
@@ -86,7 +94,7 @@ public class KafkaStringConsumer {
         try {
             consumer.close();
         } catch (Exception e) {
-            e.printStackTrace(); // should not happen
+            e.printStackTrace(); // should not happen, but if it does i want to know why
         } finally {
             latch.countDown();
         }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/kafka/KafkaStringConsumer.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/kafka/KafkaStringConsumer.java
@@ -1,0 +1,94 @@
+package nl.toefel.kafka.elasticsearch.pump.kafka;
+
+import nl.toefel.kafka.elasticsearch.pump.config.Config;
+import nl.toefel.kafka.elasticsearch.pump.sink.Sink;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation based on article:
+ * https://www.confluent.io/blog/tutorial-getting-started-with-the-new-apache-kafka-0-9-consumer-client/
+ */
+public class KafkaStringConsumer {
+
+    private final KafkaConsumer<String, String> consumer;
+    private final Sink sink;
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    public static KafkaStringConsumer newStartedConsumer(Config cfg, Sink sink) {
+        KafkaStringConsumer consumer = new KafkaStringConsumer(cfg, sink);
+        List<String> topics = cfg.topicMappings.stream().map(mapping -> mapping.topic).collect(Collectors.toList());
+        System.out.println("Starting a new kafka consumer with a subscription to topics " + topics);
+        consumer.consumer.subscribe(topics);
+        new Thread(consumer::pollForMessages).start();
+        return consumer;
+    }
+
+    private KafkaStringConsumer(Config cfg, Sink sink) {
+        this.consumer = createConsumer(cfg);
+        this.sink = sink;
+    }
+
+    private KafkaConsumer<String, String> createConsumer(Config cfg) {
+        Properties props = new Properties();
+        props.put("bootstrap.servers", cfg.kafkaBootstrapServers);
+        props.put("group.id", cfg.kafkaConsumerGroupId);
+        props.put("key.deserializer", StringDeserializer.class.getName());
+        props.put("value.deserializer", StringDeserializer.class.getName());
+        return new KafkaConsumer<>(props);
+    }
+
+    public void stopSync(long timeout, TimeUnit timeUnit) {
+        System.out.println("Closing kafka consumer with a maximum wait of " + timeout + " " + timeUnit.name());
+        consumer.wakeup();
+        try {
+            boolean consumerClosedProperly = latch.await(timeout, timeUnit);
+            System.out.println(consumerClosedProperly? "Kafka consumer stopped correctly" : "Kafka consumer did not respond to stop, something appears to be wrong");
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void pollForMessages() {
+        System.out.println("Entering poll loop until consumer explicitly stopped");
+        try {
+            while (true) {
+                // polls forever until a message is available, or throws WakeupException when .wakeup() is called
+                ConsumerRecords<String, String> records = consumer.poll(Long.MAX_VALUE);
+                processExceptionSafe(records);
+                consumer.commitSync();
+            }
+        } catch (WakeupException e) {
+            // only happends when somebody calls .wakeup() on the consumer, indicating a shutdown
+        } finally {
+            close();
+        }
+    }
+
+    private void processExceptionSafe(ConsumerRecords<String, String> records) {
+        try {
+            sink.process(records);
+        } catch (Exception e) {
+            // TODO lacking a proper retry mechanism on valid backend errors, consumer should be paused and resumed
+            e.printStackTrace();
+        }
+    }
+
+    private void close() {
+        try {
+            consumer.close();
+        } catch (Exception e) {
+            e.printStackTrace(); // should not happen
+        } finally {
+            latch.countDown();
+        }
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/AutoIdStrategy.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/AutoIdStrategy.java
@@ -1,0 +1,16 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public class AutoIdStrategy implements ElasticsearchRecordIdStrategy {
+
+    @Override
+    public String getElasticSearchId(ConsumerRecord<String, String> record) {
+        return "";
+    }
+
+    @Override
+    public String getElkHttpMethod() {
+        return "POST";
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
@@ -1,0 +1,81 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import nl.toefel.kafka.elasticsearch.pump.config.Config;
+import nl.toefel.kafka.elasticsearch.pump.config.TopicElasticsearchMapping;
+import nl.toefel.kafka.elasticsearch.pump.json.Jsonizer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toMap;
+import static nl.toefel.kafka.elasticsearch.pump.json.Jsonizer.fromJson;
+
+/**
+ *
+ */
+public class ElasticsearchBulkHttpSink implements Sink {
+
+    private final Config config;
+    private final Map<String, TopicElasticsearchMapping> mappingByTopic;
+
+    public ElasticsearchBulkHttpSink(Config config) {
+        this.config = config;
+        this.mappingByTopic = this.config.topicMappings.stream().collect(toMap(x -> x.topic, Function.identity()));
+    }
+
+    @Override
+    public void process(ConsumerRecords<String, String> batch) {
+        Map<String, List<ConsumerRecord<String, String>>> recordBatchByTopic = groupRecordsByTopic(batch);
+
+        recordBatchByTopic.keySet()
+                .stream()
+                .filter(mappingByTopic::containsKey) // defensively filter any topics for which we do not have a mapping
+                .forEach(topic -> sendToElk(mappingByTopic.get(topic), recordBatchByTopic.get(topic)));
+    }
+
+    private Map<String, List<ConsumerRecord<String, String>>> groupRecordsByTopic(ConsumerRecords<String, String> batch) {
+        // add all items to a list so we can use the stream API
+        List<ConsumerRecord<String, String>> records = new ArrayList<>();
+        batch.iterator().forEachRemaining(records::add);
+
+        // groupBy topic
+        return records.stream().collect(groupingBy(ConsumerRecord::topic));
+    }
+
+    private void sendToElk(TopicElasticsearchMapping topicElasticsearchMapping, List<ConsumerRecord<String, String>> consumerRecords) {
+        for (ConsumerRecord<String, String> record : consumerRecords) {
+            try {
+                Map<String, Object> json = Jsonizer.fromJson(record.value());
+                unifyTimestamps(json);
+                //SEND
+            } catch (Exception e) {
+                System.out.println("Error transforming to json, skipping record: " + record.value());
+            }
+        }
+    }
+
+    private void unifyTimestamps(Map<String, Object> parsedJson) {
+        Object timestamp = parsedJson.get("timestamp");
+        if (timestamp != null) {
+            parsedJson.put("originalTimestampInMessage", timestamp);
+        }
+        if (timestamp instanceof Long) {
+            parsedJson.put("timestamp", ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long)timestamp), ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+        } else if (timestamp instanceof String) {
+            // nothing to do
+        } else {
+            String generatedTimestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            System.out.println("INCOMPATIBLE TIMESTAMP FORMAT " + timestamp + ", defaulting to now(): " + generatedTimestamp);
+            parsedJson.put("timestamp", generatedTimestamp);
+        }
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
@@ -140,10 +140,10 @@ public class ElasticsearchBulkHttpSink implements Sink {
                 retryCurl = "\n - manual retry: " + toCurlCommand(request, json);
             }
             System.out.println("http error status=" + response.statusCode() + ", body=" + response.body() + retryCurl);
-            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".failed");
-            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".failed." + response.statusCode());
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall." + request.method() + ".failed");
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall." + request.method() + ".failed." + response.statusCode());
         } else {
-            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".ok");
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall." + request.method() + ".ok");
         }
     }
 

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchBulkHttpSink.java
@@ -1,45 +1,55 @@
 package nl.toefel.kafka.elasticsearch.pump.sink;
 
+import jdk.incubator.http.HttpClient;
+import jdk.incubator.http.HttpRequest;
+import jdk.incubator.http.HttpResponse;
 import nl.toefel.kafka.elasticsearch.pump.config.Config;
 import nl.toefel.kafka.elasticsearch.pump.config.TopicElasticsearchMapping;
 import nl.toefel.kafka.elasticsearch.pump.json.Jsonizer;
+import nl.toefel.patan.api.Stopwatch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
-import static nl.toefel.kafka.elasticsearch.pump.json.Jsonizer.fromJson;
+import static nl.toefel.kafka.elasticsearch.pump.statistics.Statistics.STATS;
 
-/**
- *
- */
 public class ElasticsearchBulkHttpSink implements Sink {
 
+    private final HttpClient http = HttpClient.newHttpClient();
     private final Config config;
     private final Map<String, TopicElasticsearchMapping> mappingByTopic;
+    private final Map<String, ElasticsearchRecordIdStrategy> idStrategyByTopic;
 
-    public ElasticsearchBulkHttpSink(Config config) {
+    public ElasticsearchBulkHttpSink(Config config, ElasticsearchIdFactory idFactory) {
         this.config = config;
         this.mappingByTopic = this.config.topicMappings.stream().collect(toMap(x -> x.topic, Function.identity()));
+        this.idStrategyByTopic = this.config.topicMappings.stream().collect(toMap(x -> x.topic, idFactory::getStrategy));
     }
 
     @Override
     public void process(ConsumerRecords<String, String> batch) {
-        Map<String, List<ConsumerRecord<String, String>>> recordBatchByTopic = groupRecordsByTopic(batch);
+        STATS.engine.recordElapsedTime("elasticsearch.bulk.http.sink.process.batch", () -> {
+            Map<String, List<ConsumerRecord<String, String>>> recordBatchByTopic = groupRecordsByTopic(batch);
 
-        recordBatchByTopic.keySet()
-                .stream()
-                .filter(mappingByTopic::containsKey) // defensively filter any topics for which we do not have a mapping
-                .forEach(topic -> sendToElk(mappingByTopic.get(topic), recordBatchByTopic.get(topic)));
+            recordBatchByTopic.keySet()
+                    .stream()
+                    .filter(mappingByTopic::containsKey) // defensively filter any topics for which we do not have a mapping
+                    .forEach(topic -> sendToElasticsearch(mappingByTopic.get(topic), recordBatchByTopic.get(topic)));
+        });
     }
 
     private Map<String, List<ConsumerRecord<String, String>>> groupRecordsByTopic(ConsumerRecords<String, String> batch) {
@@ -51,31 +61,93 @@ public class ElasticsearchBulkHttpSink implements Sink {
         return records.stream().collect(groupingBy(ConsumerRecord::topic));
     }
 
-    private void sendToElk(TopicElasticsearchMapping topicElasticsearchMapping, List<ConsumerRecord<String, String>> consumerRecords) {
+    private void sendToElasticsearch(TopicElasticsearchMapping mappingConfig, List<ConsumerRecord<String, String>> consumerRecords) {
+        STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.send.to.elasticsearch.topic." + mappingConfig.topic);
         for (ConsumerRecord<String, String> record : consumerRecords) {
-            try {
-                Map<String, Object> json = Jsonizer.fromJson(record.value());
-                unifyTimestamps(json);
-                //SEND
-            } catch (Exception e) {
-                System.out.println("Error transforming to json, skipping record: " + record.value());
-            }
+            STATS.engine.recordElapsedTime("elasticsearch.bulk.http.sink.process.single", () -> {
+                try {
+                    Map<String, Object> parsedRecord = Jsonizer.fromJson(record.value());
+                    parsedRecord = unifyTimestamps(parsedRecord);
+                    if (Boolean.TRUE.equals(mappingConfig.addKafkaMetaData)) {
+                        parsedRecord = insertKafkaRecordFieldsAsMeta(parsedRecord, record);
+                    }
+                    ElasticsearchRecordIdStrategy idStrategy = idStrategyByTopic.get(mappingConfig.topic);
+                    String json = Jsonizer.toJsonMinified(parsedRecord);
+                    http(mappingConfig, idStrategy.getElkHttpMethod(), idStrategy.getElasticSearchId(record), json);
+                } catch (Exception e) {
+                    System.out.println("Error transforming to json, skipping record: " + record.value());
+                }
+            });
         }
     }
 
-    private void unifyTimestamps(Map<String, Object> parsedJson) {
-        Object timestamp = parsedJson.get("timestamp");
+    // modifies the input map, and returns the same instance!
+    private Map<String, Object> unifyTimestamps(Map<String, Object> parsedRecord) {
+        Object timestamp = parsedRecord.get("timestamp");
         if (timestamp != null) {
-            parsedJson.put("originalTimestampInMessage", timestamp);
+            parsedRecord.put("originalTimestampInMessage", timestamp);
         }
         if (timestamp instanceof Long) {
-            parsedJson.put("timestamp", ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long)timestamp), ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+            parsedRecord.put("timestamp", ZonedDateTime.ofInstant(Instant.ofEpochMilli((Long) timestamp), ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
         } else if (timestamp instanceof String) {
             // nothing to do
         } else {
-            String generatedTimestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+            String generatedTimestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME);
             System.out.println("INCOMPATIBLE TIMESTAMP FORMAT " + timestamp + ", defaulting to now(): " + generatedTimestamp);
-            parsedJson.put("timestamp", generatedTimestamp);
+            parsedRecord.put("timestamp", generatedTimestamp);
         }
+        return parsedRecord;
+    }
+
+    private Map<String, Object> insertKafkaRecordFieldsAsMeta(Map<String, Object> parsedRecord, ConsumerRecord<String, String> record) {
+        HashMap<String, Object> meta = new HashMap<>();
+        meta.put("topic", record.topic());
+        meta.put("partition", record.partition());
+        meta.put("key", record.key());
+        meta.put("offset", record.offset());
+        meta.put("serializedValueSize", record.serializedValueSize());
+        meta.put("serializedKeySize", record.serializedKeySize());
+        meta.put("timestamp", record.timestamp());
+        parsedRecord.put("_kafkaMetaData", meta);
+        return parsedRecord;
+    }
+
+    private void http(TopicElasticsearchMapping mappingConfig, String method, String idInElk, String json) throws IOException, InterruptedException {
+        String uri = "http://" + Paths.get(
+                config.elasticsearchServer,
+                mappingConfig.elasticsearchIndex,
+                mappingConfig.elasticsearchType,
+                idInElk);
+
+        HttpRequest request = HttpRequest.newBuilder(URI.create(uri))
+                .header("Content-Type", "application/json")
+                .method(method, HttpRequest.BodyProcessor.fromString(json))
+                .build();
+
+        if ("always".equalsIgnoreCase(mappingConfig.logCurlCommands)) {
+            System.out.println(toCurlCommand(request, json));
+        }
+        Stopwatch sw = STATS.engine.startStopwatch();
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandler.asString());
+        STATS.engine.recordElapsedTime("elasticsearch.bulk.http.sink.httpcall." + method, sw);
+        logHttpResult(mappingConfig, request, json, response); // TODO built-in retry on failure, throw RetryException and defer to consumer
+    }
+
+    private void logHttpResult(TopicElasticsearchMapping mappingConfig, HttpRequest request, String json, HttpResponse<String> response) {
+        if (response.statusCode() >= 300 || response.statusCode() < 200) {
+            String retryCurl = "";
+            if ("onFailure".equalsIgnoreCase(mappingConfig.logCurlCommands)) {
+                retryCurl = "\n - manual retry: " + toCurlCommand(request, json);
+            }
+            System.out.println("http error status=" + response.statusCode() + ", body=" + response.body() + retryCurl);
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".failed");
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".failed." + response.statusCode());
+        } else {
+            STATS.engine.addOccurrence("elasticsearch.bulk.http.sink.httpcall" + request.method() + ".ok");
+        }
+    }
+
+    private static String toCurlCommand(HttpRequest request, String body) {
+        return String.format("curl -X%s -H 'Content-Type: application/json' %s -d '%s'", request.method(), request.uri().toString(), body);
     }
 }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchIdFactory.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchIdFactory.java
@@ -1,0 +1,24 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import nl.toefel.kafka.elasticsearch.pump.config.TopicElasticsearchMapping;
+
+public class ElasticsearchIdFactory {
+    public ElasticsearchRecordIdStrategy getStrategy(TopicElasticsearchMapping mapping) {
+        if (mapping.elasticsearchIdStrategy == null || mapping.elasticsearchIdStrategy.isEmpty()) {
+            System.out.println("elasticsearchIdStrategy is null for " + mapping.topic + ", defaulting to auto");
+            mapping.elasticsearchIdStrategy = "auto";
+        }
+        switch (mapping.elasticsearchIdStrategy) {
+            case "random":
+                return new RandomIdStrategy();
+            case "fromField":
+                return new FromFieldIdStrategy(mapping.pathToIdInMessage.orElseThrow(() -> new IllegalStateException("fromField requires pathToIdInMessage to be a JSON path to the ID in Kafka")));
+            case "fromKafkaKey":
+                return new FromKafkaKeyIdStrategy();
+            case "auto":
+                return new AutoIdStrategy();
+            default:
+                throw new IllegalStateException("unknown ID strategy " + mapping.elasticsearchIdStrategy + ", use auto, random, fromField or fromKafkaKey");
+        }
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchRecordIdStrategy.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/ElasticsearchRecordIdStrategy.java
@@ -1,0 +1,8 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public interface ElasticsearchRecordIdStrategy {
+    String getElasticSearchId(ConsumerRecord<String, String> record);
+    String getElkHttpMethod();
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/FromFieldIdStrategy.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/FromFieldIdStrategy.java
@@ -1,0 +1,25 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.UUID;
+
+public class FromFieldIdStrategy implements ElasticsearchRecordIdStrategy {
+
+    private String jsonPathToField;
+
+    public FromFieldIdStrategy(String jsonPathToField) {
+        this.jsonPathToField = jsonPathToField;
+        throw new IllegalStateException("FromField not yet implemented");
+    }
+
+    @Override
+    public String getElasticSearchId(ConsumerRecord<String, String> record) {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getElkHttpMethod() {
+        return "PUT";
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/FromKafkaKeyIdStrategy.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/FromKafkaKeyIdStrategy.java
@@ -1,0 +1,18 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.UUID;
+
+public class FromKafkaKeyIdStrategy implements ElasticsearchRecordIdStrategy {
+
+    @Override
+    public String getElasticSearchId(ConsumerRecord<String, String> record) {
+        return record.key();
+    }
+
+    @Override
+    public String getElkHttpMethod() {
+        return "PUT";
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/RandomIdStrategy.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/RandomIdStrategy.java
@@ -1,0 +1,18 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.UUID;
+
+public class RandomIdStrategy implements ElasticsearchRecordIdStrategy {
+
+    @Override
+    public String getElasticSearchId(ConsumerRecord<String, String> record) {
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public String getElkHttpMethod() {
+        return "PUT";
+    }
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/Sink.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/Sink.java
@@ -4,5 +4,5 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 public interface Sink {
 
-    void process(ConsumerRecords<String, String> batch) throws RetryException;
+    void process(ConsumerRecords<String, String> batch);
 }

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/Sink.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/sink/Sink.java
@@ -1,0 +1,8 @@
+package nl.toefel.kafka.elasticsearch.pump.sink;
+
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+public interface Sink {
+
+    void process(ConsumerRecords<String, String> batch) throws RetryException;
+}

--- a/src/main/java/nl/toefel/kafka/elasticsearch/pump/statistics/Statistics.java
+++ b/src/main/java/nl/toefel/kafka/elasticsearch/pump/statistics/Statistics.java
@@ -1,0 +1,10 @@
+package nl.toefel.kafka.elasticsearch.pump.statistics;
+
+import nl.toefel.patan.StatisticsFactory;
+
+public enum Statistics {
+    STATS;
+
+    public final nl.toefel.patan.api.Statistics engine = StatisticsFactory.createThreadsafeStatistics();
+
+}


### PR DESCRIPTION
Kafka streams does not play well with older clients and has trouble with some messages sent via .NET and Golang.

The kafka-clients API also polls batches, which can be inserted in bulk into ELK, which is more efficient.